### PR TITLE
feature/quilt-management-pull

### DIFF
--- a/step/step.py
+++ b/step/step.py
@@ -210,7 +210,7 @@ class Step(ABC):
         package_name = self.__module__.split(".")[0]
 
         # Browse top level project package
-        p = quilt3.Package.browse(package_name, bucket)
+        p = quilt3.Package.browse(package_name, bucket, top_hash=data_version)
 
         # Check to see if step data exists on this branch in quilt
         try:

--- a/step/step.py
+++ b/step/step.py
@@ -113,8 +113,8 @@ class Step(ABC):
 
         # figure out what branch we're on and what package we're a part of
         repo = git.Repo(Path(".").expanduser().resolve())
-        self.current_branch = repo.active_branch.name
-        self.package_name = self.__module__.split(".")[0]
+        self._current_branch = repo.active_branch.name
+        self._package_name = self.__module__.split(".")[0]
 
 
     @property
@@ -136,6 +136,15 @@ class Step(ABC):
     @property
     def step_local_staging_dir(self) -> Path:
         return self._step_local_staging_dir
+
+    @property
+    def current_branch(self) -> str:
+        return self._current_branch
+
+    @property
+    def package_name(self) -> str:
+        return self._package_name
+
 
     @abstractmethod
     def _run(self, **kwargs):

--- a/step/step.py
+++ b/step/step.py
@@ -179,15 +179,9 @@ class Step(ABC):
         current_branch = repo.active_branch.name
         package_name = self.__module__.split(".")[0]
 
-        # Load this module
-        mymodule = importlib.import_module(package_name)
-        from mymodule import steps
-
         # Run checkout for each upstream
         for upstream_task in self.upstream_tasks:
-            parent_step = steps.getattr(upstream_task)
-            parent_step.checkout()
-            # this won't work bcx dirs are lowercase and clases are uppercase
+            upstream_task.checkout(data_version=data_version, bucket=bucket)
 
     def checkout(
         self,
@@ -222,8 +216,6 @@ class Step(ABC):
 
         # Fetch the data and save it to the local staging dir
         p[quilt_loc].fetch(self.step_local_staging_dir)
-
-
 
     def push(self, bucket: Optional[str] = None):
         # Resolve None bucket

--- a/step/step.py
+++ b/step/step.py
@@ -7,7 +7,6 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional, Union
-import importlib
 
 import quilt3
 import git

--- a/step/step.py
+++ b/step/step.py
@@ -175,30 +175,26 @@ class Step(ABC):
         # Resolve save_dir
         save_dir = file_utils.resolve_directory(save_dir, make=True)
 
-        # checkout this step's output from quilt.
-        # check for files on this branch and default to master
+        # Checkout this step's output from quilt
+        # Check for files on this branch and default to master
 
         # Resolve the project and branch for use in quilt paths
         repo = git.Repo(Path(".").expanduser().resolve())
         current_branch = repo.active_branch.name
         package_name = self.__module__.split(".")[0]
 
-        # paths to the data we want on quilt, for this branch and master
-        quilt_target_branch = f"{package_name}/{current_branch}/{self.step_name}"
-        quilt_target_master = f"{package_name}/master/{self.step_name}"
-
-        # browse top level project package
+        # Browse top level project package
         p = quilt3.Package.browse(package_name, bucket)
 
-        # check to see if step data exists on this branch in quilt
+        # Check to see if step data exists on this branch in quilt
         try:
-            quilt_loc = p[checkout_target_branch]
+            quilt_loc = p[f"{package_name}/{current_branch}/{self.step_name}"]
 
-        # if not, use the version on master
+        # If not, use the version on master
         except KeyError:
-            quilt_loc = p[checkout_target_master]
+            quilt_loc = p[f"{package_name}/master/{self.step_name}"]
 
-        # fetch the data and save it to the local staging dir
+        # Fetch the data and save it to the local staging dir
         p[quilt_loc].fetch(self.step_local_staging_dir)
 
 

--- a/step/step.py
+++ b/step/step.py
@@ -7,6 +7,7 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional, Union
+import importlib
 
 import quilt3
 import git
@@ -158,9 +159,20 @@ class Step(ABC):
         # Resolve save_dir
         save_dir = file_utils.resolve_directory(save_dir, make=True)
 
+        # Resolve the project and branch for use in quilt paths
+        repo = git.Repo(Path(".").expanduser().resolve())
+        current_branch = repo.active_branch.name
+        package_name = self.__module__.split(".")[0]
+
+        # Load this module
+        mymodule = importlib.import_module(package_name)
+        from mymodule import steps
+
         # Run checkout for each upstream
         for upstream_task in self.upstream_tasks:
-            pass
+            parent_step = steps.getattr(upstream_task)
+            parent_step.checkout()
+            # this won't work bcx dirs are lowercase and clases are uppercase
 
     def checkout(
         self,

--- a/step/step.py
+++ b/step/step.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
+import quilt3
 import git
 
 from . import constants, exceptions, file_utils
@@ -157,7 +158,7 @@ class Step(ABC):
         # Resolve save_dir
         save_dir = file_utils.resolve_directory(save_dir, make=True)
 
-        # Run pull for each upstream
+        # Run checkout for each upstream
         for upstream_task in self.upstream_tasks:
             pass
 
@@ -174,7 +175,33 @@ class Step(ABC):
         # Resolve save_dir
         save_dir = file_utils.resolve_directory(save_dir, make=True)
 
-        pass
+        # checkout this step's output from quilt.
+        # check for files on this branch and default to master
+
+        # Resolve the project and branch for use in quilt paths
+        repo = git.Repo(Path(".").expanduser().resolve())
+        current_branch = repo.active_branch.name
+        package_name = self.__module__.split(".")[0]
+
+        # paths to the data we want on quilt, for this branch and master
+        quilt_target_branch = f"{package_name}/{current_branch}/{self.step_name}"
+        quilt_target_master = f"{package_name}/master/{self.step_name}"
+
+        # browse top level project package
+        p = quilt3.Package.browse(package_name, bucket)
+
+        # check to see if step data exists on this branch in quilt
+        try:
+            quilt_loc = p[checkout_target_branch]
+
+        # if not, use the version on master
+        except KeyError:
+            quilt_loc = p[checkout_target_master]
+
+        # fetch the data and save it to the local staging dir
+        p[quilt_loc].fetch(self.step_local_staging_dir)
+
+
 
     def push(
         self, push_dir: Optional[Union[str, Path]] = None, bucket: Optional[str] = None,

--- a/step/step.py
+++ b/step/step.py
@@ -169,7 +169,7 @@ class Step(ABC):
     ):
         # Resolve None bucket
         if bucket is None:
-            bucket = self._storage_bucket
+            bucket = self.storage_bucket
 
         # Resolve save_dir
         save_dir = file_utils.resolve_directory(save_dir, make=True)
@@ -196,7 +196,7 @@ class Step(ABC):
     ):
         # Resolve None bucket
         if bucket is None:
-            bucket = self._storage_bucket
+            bucket = self.storage_bucket
 
         # Resolve save_dir
         save_dir = file_utils.resolve_directory(save_dir, make=True)

--- a/step/step.py
+++ b/step/step.py
@@ -171,9 +171,6 @@ class Step(ABC):
         if bucket is None:
             bucket = self.storage_bucket
 
-        # Resolve save_dir
-        save_dir = file_utils.resolve_directory(save_dir, make=True)
-
         # Resolve the project and branch for use in quilt paths
         repo = git.Repo(Path(".").expanduser().resolve())
         current_branch = repo.active_branch.name
@@ -191,9 +188,6 @@ class Step(ABC):
         # Resolve None bucket
         if bucket is None:
             bucket = self.storage_bucket
-
-        # Resolve save_dir
-        save_dir = file_utils.resolve_directory(save_dir, make=True)
 
         # Checkout this step's output from quilt
         # Check for files on this branch and default to master

--- a/step/step.py
+++ b/step/step.py
@@ -92,7 +92,7 @@ class Step(ABC):
 
     def __init__(
         self,
-        direct_upstream_tasks: Optional[List[Step]] = None,
+        direct_upstream_tasks: Optional[List["Step"]] = None,
         config: Optional[Union[str, Path, Dict[str, str]]] = None,
     ):
         # Set step name

--- a/step/step.py
+++ b/step/step.py
@@ -92,7 +92,7 @@ class Step(ABC):
 
     def __init__(
         self,
-        direct_upstream_tasks: Optional[List[str]] = None,
+        direct_upstream_tasks: Optional[List[Step]] = None,
         config: Optional[Union[str, Path, Dict[str, str]]] = None,
     ):
         # Set step name
@@ -164,7 +164,6 @@ class Step(ABC):
 
     def pull(
         self,
-        save_dir: Union[str, Path] = "",
         data_version: Optional[str] = None,
         bucket: Optional[str] = None,
     ):
@@ -192,7 +191,6 @@ class Step(ABC):
 
     def checkout(
         self,
-        save_dir: Union[str, Path] = "",
         data_version: Optional[str] = None,
         bucket: Optional[str] = None,
     ):


### PR DESCRIPTION
- upstream tasks are classes
- `pull` just iterates over checkout on upstream task classes
- checkout looks for data in quilt on the current branch, and then defaults to master
  - maybe there should be a warning on not finding it on the current branch?