### PR TITLE
Feature/clean

### DIFF
--- a/datastep/file_utils.py
+++ b/datastep/file_utils.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 from pathlib import Path
+from shutil import rmtree
 from typing import Any, Dict, List, Optional, Union
 
 ###############################################################################
@@ -91,3 +92,11 @@ def manifest_filepaths_abs2rel(mystep):
         mystep.manifest[col] = mystep.manifest[col].apply(
             lambda x: str(_filepath_abs2rel(Path(x), mystep.step_local_staging_dir))
         )
+
+
+def _clean(dirpath: Path) -> Optional[Exception]:
+    # remove anything in step staging dir
+    rmtree(dirpath)
+
+    # create it again as empty dir
+    dirpath.mkdir(parents=True, exist_ok=True)

--- a/datastep/step.py
+++ b/datastep/step.py
@@ -8,6 +8,7 @@ import os
 from abc import ABC, abstractmethod
 from functools import wraps
 from pathlib import Path
+from shutil import rmtree
 from typing import Dict, List, Optional, Union
 
 import git
@@ -114,6 +115,7 @@ class Step(ABC):
 
     def __init__(
         self,
+        clean_before_run=True,
         direct_upstream_tasks: Optional[List["Step"]] = None,
         config: Optional[Union[str, Path, Dict[str, str]]] = None,
     ):
@@ -133,6 +135,10 @@ class Step(ABC):
 
         # Unpack config
         self._unpack_config(config)
+
+        # clean old files
+        if clean_before_run:
+            file_utils._clean(self.step_local_staging_dir)
 
         # write out args/kwargs now that we know where
         parameter_store = self.step_local_staging_dir / "init_parameters.json"
@@ -316,6 +322,10 @@ class Step(ABC):
             registry=self.storage_bucket,
             message=self._create_data_commit_message(),
         )
+
+    def clean(self) -> str:
+        file_utils._clean(self.step_local_staging_dir)
+
 
     def __str__(self):
         return (

--- a/datastep/step.py
+++ b/datastep/step.py
@@ -114,6 +114,7 @@ class Step(ABC):
 
     def __init__(
         self,
+        clean_before_run=True,
         direct_upstream_tasks: Optional[List["Step"]] = None,
         config: Optional[Union[str, Path, Dict[str, str]]] = None,
     ):
@@ -133,6 +134,10 @@ class Step(ABC):
 
         # Unpack config
         self._unpack_config(config)
+
+        # clean old files
+        if clean_before_run:
+            file_utils._clean(self.step_local_staging_dir)
 
         # write out args/kwargs now that we know where
         parameter_store = self.step_local_staging_dir / "init_parameters.json"
@@ -316,6 +321,9 @@ class Step(ABC):
             registry=self.storage_bucket,
             message=self._create_data_commit_message(),
         )
+
+    def clean(self) -> str:
+        file_utils._clean(self.step_local_staging_dir)
 
     def __str__(self):
         return (

--- a/datastep/step.py
+++ b/datastep/step.py
@@ -8,7 +8,6 @@ import os
 from abc import ABC, abstractmethod
 from functools import wraps
 from pathlib import Path
-from shutil import rmtree
 from typing import Dict, List, Optional, Union
 
 import git

--- a/datastep/tests/example_step.py
+++ b/datastep/tests/example_step.py
@@ -12,8 +12,8 @@ from datastep import Step
 
 # A dummy class to test with
 class ExampleStep(Step):
-    def __init__(self, direct_upstream_tasks=None, config=None):
-        super().__init__(direct_upstream_tasks, config)
+    def __init__(self, clean_before_run=True, direct_upstream_tasks=None, config=None):
+        super().__init__(clean_before_run, direct_upstream_tasks, config)
 
     def run(self, N=3):
         # make a directory of empty files

--- a/datastep/tests/test_step.py
+++ b/datastep/tests/test_step.py
@@ -270,3 +270,16 @@ def test_init(
     # Reset current working directory
     if use_cwd is not None:
         os.chdir(original_dir)
+
+
+def test_run():
+    t = ExampleStep(direct_upstream_tasks=direct_upstream_tasks, config=config_var)
+    t.run()
+    assert len([file for file in t.step_local_staging_dir.iterdir()]) > 0
+
+
+def test_clean():
+    t = ExampleStep(direct_upstream_tasks=direct_upstream_tasks, config=config_var)
+    t.run()
+    t.clean()
+    assert len([file for file in t.step_local_staging_dir.iterdir()]) == 0

--- a/datastep/tests/test_step.py
+++ b/datastep/tests/test_step.py
@@ -270,3 +270,16 @@ def test_init(
     # Reset current working directory
     if use_cwd is not None:
         os.chdir(original_dir)
+
+
+def test_run():
+    t = ExampleStep()
+    t.run()
+    assert len([file for file in t.step_local_staging_dir.iterdir()]) > 0
+
+
+def test_clean():
+    t = ExampleStep()
+    t.run()
+    t.clean()
+    assert len([file for file in t.step_local_staging_dir.iterdir()]) == 0

--- a/datastep/tests/test_step.py
+++ b/datastep/tests/test_step.py
@@ -273,13 +273,13 @@ def test_init(
 
 
 def test_run():
-    t = ExampleStep(direct_upstream_tasks=direct_upstream_tasks, config=config_var)
+    t = ExampleStep()
     t.run()
     assert len([file for file in t.step_local_staging_dir.iterdir()]) > 0
 
 
 def test_clean():
-    t = ExampleStep(direct_upstream_tasks=direct_upstream_tasks, config=config_var)
+    t = ExampleStep()
     t.run()
     t.clean()
     assert len([file for file in t.step_local_staging_dir.iterdir()]) == 0


### PR DESCRIPTION
**Pull request recommendations:**

Resolves issues #2 and #9 

Main changes:
- `_clean` function in `file_utils`
- `clean` method for each step
- `clean_before_run` kwarg in `__init__` that calls `_clean` (defaults to `True`)
- tests for the clean method

