### PR TITLE
rename quilt cli class to allow import

### DIFF
--- a/datastep/quilt_utils.py
+++ b/datastep/quilt_utils.py
@@ -354,7 +354,7 @@ def create_package(
 
 # used in cookiecutter template to init quilt repo
 # nd other quilt-centric cmdline tasks as methods here
-class _Quilt:
+class QuiltCli:
     def __init__(self, config_file="step_config.json", **kwargs):
 
         # get package name from name of python package


### PR DESCRIPTION
couldn't import this from the step library because of the underscore in the name.  changed it to something more normal and things ran locally again.