### PR TITLE
admin/upgrade-from-cookiecutter

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Dependencies
       run: |
         pip install --upgrade pip
@@ -29,4 +29,3 @@ jobs:
         BASE_BRANCH: master # The branch the action should deploy from.
         BRANCH: gh-pages # The branch the action should deploy to.
         FOLDER: docs/_build/html/ # The folder the action should deploy.
-

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -14,13 +14,12 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -38,15 +37,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - uses: actions/checkout@v1
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
     - name: Lint with flake8
       run: |
-        flake8 datastep --count --verbose --max-line-length=127 --show-source --statistics
+        flake8 datastep --count --verbose --show-source --statistics
+    - name: Check with black
+      run: |
+        black --check datastep

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -6,13 +6,12 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 6
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -29,15 +28,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - uses: actions/checkout@v1
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
     - name: Lint with flake8
       run: |
-        flake8 datastep --count --verbose --max-line-length=127 --show-source --statistics
+        flake8 datastep --count --verbose --show-source --statistics
+    - name: Check with black
+      run: |
+        black --check datastep

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -18,8 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install poetry
+        python -m pip install pip==18.1
         pip install .[test]
     - name: Test with pytest
       run: |

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install poetry
         pip install .[test]
     - name: Test with pytest
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,45 +6,46 @@ helps, and credit will always be given.
 ## Get Started!
 Ready to contribute? Here's how to set up `datastep` for local development.
 
-* Fork the `datastep` repo on GitHub.
-* Clone your fork locally:
+1. Fork the `datastep` repo on GitHub.
 
-```
-$ git clone --recurse-submodules git@github.com:{your_name_here}/datastep.git
-```
+2. Clone your fork locally:
 
-* Install the project in editable mode. (It is also recommended to work in a
-virtualenv or anaconda environment):
+    ```bash
+    git clone git@github.com:{your_name_here}/datastep.git
+    ```
 
-```
-$ cd datastep/
-$ pip install -e .[dev]
-```
+3. Install the project in editable mode. (It is also recommended to work in a virtualenv or anaconda environment):
 
-* Create a branch for local development:
+    ```bash
+    cd datastep/
+    pip install -e .[dev]
+    ```
 
-```
-$ git checkout -b {your_development_type}/short-description
-```
-Ex: feature/read-tiff-files or bugfix/handle-file-not-found<br>
-Now you can make your changes locally.<br>
+4. Create a branch for local development:
 
-* When you're done making changes, check that your changes pass linting and
-tests, including testing other Python versions with make:
+    ```bash
+    git checkout -b {your_development_type}/short-description
+    ```
 
-```
-$ make build
-```
+    Ex: feature/read-tiff-files or bugfix/handle-file-not-found<br>
+    Now you can make your changes locally.
 
-* Commit your changes and push your branch to GitHub:
+5. When you're done making changes, check that your changes pass linting and
+   tests, including testing other Python versions with make:
 
-```
-$ git add .
-$ git commit -m "Resolves gh-###. Your detailed description of your changes."
-$ git push origin {your_development_type}/short-description
-```
+    ```bash
+    make build
+    ```
 
-* Submit a pull request through the GitHub website.
+6. Commit your changes and push your branch to GitHub:
+
+    ```bash
+    git add .
+    git commit -m "Resolves gh-###. Your detailed description of your changes."
+    git push origin {your_development_type}/short-description
+    ```
+
+7. Submit a pull request through the GitHub website.
 
 ## Deploying
 
@@ -52,11 +53,13 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed.
 Then run:
 
-```
+```bash
 $ bumpversion patch # possible: major / minor / patch
 $ git push
 $ git push --tags
+git branch -D stable
+git checkout -b stable
+git push --set-upstream origin stable -f
 ```
 
-Make and merge a PR to branch `stable` and GitHub will then deploy to PyPI once
-merged.
+This will release a new package version on Git + GitHub and publish to PyPI.

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,6 @@ gen-docs: ## generate Sphinx HTML documentation, including API docs
 	sphinx-apidoc -o docs/ datastep **/tests/
 	$(MAKE) -C docs html
 
-docs: ## generate Sphinx HTML documentation and serve to browser
+docs: ## generate Sphinx HTML documentation, including API docs, and serve to browser
 	make gen-docs
 	$(BROWSER) docs/_build/html/index.html

--- a/datastep/bin/make_new_step.py
+++ b/datastep/bin/make_new_step.py
@@ -187,8 +187,8 @@ def _find_steps_dir():
                         return subd
 
     return exceptions.DirectoryNotFoundError(
-        f"Could not find 'steps' directory."
-        f"This script must be run from the head of your repo."
+        "Could not find 'steps' directory."
+        "This script must be run from the head of your repo."
     )
 
 

--- a/datastep/step.py
+++ b/datastep/step.py
@@ -178,7 +178,7 @@ class Step(Task):
 
         else:
             # Log debug message indicating using defaults
-            log.debug(f"Using default project and step configuration.")
+            log.debug("Using default project and step configuration.")
 
             # Construct config dictionary object
             config = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,17 +14,18 @@ replace = {new_version}
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = docs
-max-line-length = 88
-ignore = 
-	E203
-	W291
-	W503
-
 [aliases]
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
 
+[flake8]
+exclude =
+	docs/
+ignore =
+	E203
+	E402
+	W291
+	W503
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -8,35 +8,34 @@ from setuptools import find_packages, setup
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
-test_requirements = [
-    "codecov",
-    "flake8",
-    "black",
-    "pytest",
-    "pytest-cov",
-    "pytest-raises",
+setup_requirements = [
+    "pytest-runner>=5.2",
 ]
 
-setup_requirements = ["pytest-runner"]
+test_requirements = [
+    "black>=19.10b0",
+    "codecov>=2.1.4",
+    "flake8>=3.8.3",
+    "flake8-debugger>=3.2.1",
+    "pytest>=5.4.3",
+    "pytest-cov>=2.9.0",
+    "pytest-raises>=0.11",
+]
 
 dev_requirements = [
-    "bumpversion>=0.5.3",
-    "coverage>=5.0a4",
-    "flake8>=3.7.7",
-    "ipython>=7.5.0",
+    *setup_requirements,
+    *test_requirements,
+    "bumpversion>=0.6.0",
+    "coverage>=5.1",
+    "ipython>=7.15.0",
     "m2r>=0.2.1",
-    "pytest>=4.3.0",
-    "pytest-cov==2.6.1",
-    "pytest-raises>=0.10",
-    "pytest-runner>=4.4",
-    "Sphinx>=2.0.0b1",
-    "sphinx_rtd_theme>=0.1.6",
-    "tox>=3.5.2",
-    "twine>=1.13.0",
-    "wheel>=0.33.1",
+    "pytest-runner>=5.2",
+    "Sphinx>=2.0.0b1,<3",
+    "sphinx_rtd_theme>=0.4.3",
+    "tox>=3.15.2",
+    "twine>=3.1.1",
+    "wheel>=0.34.2",
 ]
-
-interactive_requirements = ["altair", "jupyterlab", "matplotlib"]
 
 requirements = [
     "boto3>=1.11.9",
@@ -53,17 +52,13 @@ requirements = [
 ]
 
 extra_requirements = {
-    "test": test_requirements,
     "setup": setup_requirements,
+    "test": test_requirements,
     "dev": dev_requirements,
-    "interactive": interactive_requirements,
     "all": [
         *requirements,
-        *test_requirements,
-        *setup_requirements,
         *dev_requirements,
-        *interactive_requirements,
-    ],
+    ]
 }
 
 setup(
@@ -74,18 +69,21 @@ setup(
         "Intended Audience :: Developers",
         "License :: Free for non-commercial use",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.6"
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
-    description="A base class and utilities for creating steps in DAGs that are tied "
-    "to large amounts of data.",
+    description=(
+        "A base class and utilities for creating steps in DAGs that are tied "
+        "to large amounts of data."
+    ),
     entry_points={"console_scripts": ["make_new_step=datastep.bin.make_new_step:main"]},
     install_requires=requirements,
     license="Allen Institute Software License",
     long_description=readme,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    keywords="datastep, DAG, data, stepwise",
+    keywords="datastep, DAG, pipeline, workflow",
     name="datastep",
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: Free for non-commercial use",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,12 @@
-[flake8]
-exclude = datastep/vendor/*
-
 [tox]
 skipsdist = True
-envlist = py36, py37, lint
-
-[pytest]
-markers =
-    raises
+envlist = py36, py37, py38, lint
 
 [testenv:lint]
 deps =
     .[test]
 commands =
-    flake8 datastep --count --verbose --max-line-length=127 --show-source --statistics
+    flake8 datastep --count --verbose --show-source --statistics
     black --check datastep
 
 [testenv]


### PR DESCRIPTION
Fixes broken build and updates the repo to be the latest cookiecutter, except it still builds and allows py36 to be used as I know we have active projects using py36 and datastep.